### PR TITLE
Add PayInvoiceRequest and PayInvoiceResponse types

### DIFF
--- a/src/main/java/cc/getportal/command/request/PayInvoiceRequest.java
+++ b/src/main/java/cc/getportal/command/request/PayInvoiceRequest.java
@@ -1,0 +1,24 @@
+package cc.getportal.command.request;
+
+import cc.getportal.command.PortalRequest;
+import cc.getportal.command.notification.UnitNotification;
+import cc.getportal.command.response.PayInvoiceResponse;
+
+public class PayInvoiceRequest extends PortalRequest<PayInvoiceResponse, UnitNotification> {
+
+    private final String invoice;
+
+    public PayInvoiceRequest(String invoice) {
+        this.invoice = invoice;
+    }
+
+    @Override
+    public String name() {
+        return "PayInvoice";
+    }
+
+    @Override
+    public Class<PayInvoiceResponse> responseType() {
+        return PayInvoiceResponse.class;
+    }
+}

--- a/src/main/java/cc/getportal/command/response/PayInvoiceResponse.java
+++ b/src/main/java/cc/getportal/command/response/PayInvoiceResponse.java
@@ -1,0 +1,9 @@
+package cc.getportal.command.response;
+
+import cc.getportal.command.PortalResponse;
+
+public record PayInvoiceResponse(
+    String preimage
+) implements PortalResponse {
+
+}


### PR DESCRIPTION
Adds PayInvoice request/response types to the SDK, matching the PayInvoice command added in lib (PR #144).

- `PayInvoiceRequest`: takes an invoice string, returns `PayInvoiceResponse`
- `PayInvoiceResponse`: record with `preimage` field

This allows JVM consumers to use PayInvoice without defining local types.