### PR TITLE
feat: add GetWalletInfo command

### DIFF
--- a/src/main/java/cc/getportal/command/request/GetWalletInfoRequest.java
+++ b/src/main/java/cc/getportal/command/request/GetWalletInfoRequest.java
@@ -1,0 +1,26 @@
+package cc.getportal.command.request;
+
+import cc.getportal.command.PortalRequest;
+import cc.getportal.command.notification.UnitNotification;
+import cc.getportal.command.response.GetWalletInfoResponse;
+
+public class GetWalletInfoRequest extends PortalRequest<GetWalletInfoResponse, UnitNotification> {
+
+    public GetWalletInfoRequest() {
+    }
+
+    @Override
+    public String name() {
+        return "GetWalletInfo";
+    }
+
+    @Override
+    public Class<GetWalletInfoResponse> responseType() {
+        return GetWalletInfoResponse.class;
+    }
+
+    @Override
+    public boolean isUnit() {
+        return true;
+    }
+}

--- a/src/main/java/cc/getportal/command/response/GetWalletInfoResponse.java
+++ b/src/main/java/cc/getportal/command/response/GetWalletInfoResponse.java
@@ -1,0 +1,6 @@
+package cc.getportal.command.response;
+
+import cc.getportal.command.PortalResponse;
+
+public record GetWalletInfoResponse(String wallet_type, long balance_msat) implements PortalResponse {
+}


### PR DESCRIPTION
Adds `GetWalletInfoRequest` and `GetWalletInfoResponse` following existing patterns.

- `GetWalletInfoRequest`: no-params command (isUnit = true), expects `GetWalletInfoResponse`, uses `UnitNotification`
- `GetWalletInfoResponse`: record with `wallet_type` (String) and `balance_msat` (long)