### PR TITLE
feat: slim RequestInvoice with RequestInvoiceParams

### DIFF
--- a/src/main/java/cc/getportal/command/request/RequestInvoiceParams.java
+++ b/src/main/java/cc/getportal/command/request/RequestInvoiceParams.java
@@ -1,6 +1,7 @@
 package cc.getportal.command.request;
 
 import cc.getportal.model.Currency;
+import com.google.gson.annotations.SerializedName;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -11,8 +12,13 @@ import org.jetbrains.annotations.Nullable;
 public record RequestInvoiceParams(
     long amount,
     Currency currency,
-    String expires_at,
+    @SerializedName("expires_at")
+    String expiresAt,
     @Nullable String description,
     @Nullable String refund_invoice
 ) {
+    
+    public RequestInvoiceParams(long amount, Currency currency, long expiresAt, @Nullable String description, @Nullable String refund_invoice) {
+        this(amount, currency, String.valueOf(expiresAt), description, refund_invoice);
+    }
 }

--- a/src/main/java/cc/getportal/command/request/RequestInvoiceParams.java
+++ b/src/main/java/cc/getportal/command/request/RequestInvoiceParams.java
@@ -15,10 +15,16 @@ public record RequestInvoiceParams(
     @SerializedName("expires_at")
     String expiresAt,
     @Nullable String description,
-    @Nullable String refund_invoice
+    @Nullable String refund_invoice,
+    /** Optional request ID. If not provided, the command ID is used by the server. */
+    @Nullable String request_id
 ) {
-    
+
     public RequestInvoiceParams(long amount, Currency currency, long expiresAt, @Nullable String description, @Nullable String refund_invoice) {
-        this(amount, currency, String.valueOf(expiresAt), description, refund_invoice);
+        this(amount, currency, String.valueOf(expiresAt), description, refund_invoice, null);
+    }
+
+    public RequestInvoiceParams(long amount, Currency currency, long expiresAt, @Nullable String description, @Nullable String refund_invoice, @Nullable String requestId) {
+        this(amount, currency, String.valueOf(expiresAt), description, refund_invoice, requestId);
     }
 }

--- a/src/main/java/cc/getportal/command/request/RequestInvoiceParams.java
+++ b/src/main/java/cc/getportal/command/request/RequestInvoiceParams.java
@@ -1,0 +1,18 @@
+package cc.getportal.command.request;
+
+import cc.getportal.model.Currency;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Slim parameters for RequestInvoice command.
+ * Server (portal-rest) computes exchange rate from amount/currency.
+ * Request ID is derived from command.id.
+ */
+public record RequestInvoiceParams(
+    long amount,
+    Currency currency,
+    String expires_at,
+    @Nullable String description,
+    @Nullable String refund_invoice
+) {
+}

--- a/src/main/java/cc/getportal/command/request/RequestInvoiceRequest.java
+++ b/src/main/java/cc/getportal/command/request/RequestInvoiceRequest.java
@@ -1,6 +1,5 @@
 package cc.getportal.command.request;
 
-import cc.getportal.model.InvoiceRequestContent;
 import cc.getportal.command.PortalRequest;
 import cc.getportal.command.notification.UnitNotification;
 import cc.getportal.command.response.RequestInvoiceResponse;
@@ -11,9 +10,9 @@ public class RequestInvoiceRequest extends PortalRequest<RequestInvoiceResponse,
 
     private final String recipient_key;
     private final List<String> subkeys;
-    private final InvoiceRequestContent content;
+    private final RequestInvoiceParams content;
 
-    public RequestInvoiceRequest(String recipientKey, List<String> subkeys, InvoiceRequestContent content) {
+    public RequestInvoiceRequest(String recipientKey, List<String> subkeys, RequestInvoiceParams content) {
         recipient_key = recipientKey;
         this.subkeys = subkeys;
         this.content = content;


### PR DESCRIPTION
Aligns with PortalTechnologiesInc/lib#158.

## Changes

- Create `RequestInvoiceParams` record (slim params for RequestInvoice)
- Remove `request_id` and `current_exchange_rate` from client params
  - `request_id` is now derived from `command.id` (server-side)
  - `current_exchange_rate` is computed by portal-rest for FIAT conversions
- Update `RequestInvoiceRequest` to use new `RequestInvoiceParams` type
- Keep `InvoiceRequestContent` in codebase for backward compat (can remove later if unused)

## Related

- PortalTechnologiesInc/lib#158 (portal-rest invoice validation + slim params)
- PortalTechnologiesInc/lib#157 (original bug: missing invoice amount validation)