### PR TITLE
chore: release 0.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "cc.getportal"
-version = "0.2.1"
+version = "0.3.0"
 
 java {
     toolchain {
@@ -23,7 +23,7 @@ publishing {
 
             groupId = "cc.getportal"
             artifactId = "portal-java-sdk"
-            version = "0.2.1"
+            version = "0.3.0"
         }
     }
 }

--- a/src/main/java/cc/getportal/command/request/RequestInvoiceParams.java
+++ b/src/main/java/cc/getportal/command/request/RequestInvoiceParams.java
@@ -1,6 +1,7 @@
 package cc.getportal.command.request;
 
 import cc.getportal.model.Currency;
+import com.google.gson.annotations.SerializedName;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -11,8 +12,13 @@ import org.jetbrains.annotations.Nullable;
 public record RequestInvoiceParams(
     long amount,
     Currency currency,
-    String expires_at,
+    @SerializedName("expires_at")
+    String expiresAt,
     @Nullable String description,
     @Nullable String refund_invoice
 ) {
+    
+    public RequestInvoiceParams(long amount, Currency currency, long expiresAt, @Nullable String description, @Nullable String refund_invoice) {
+        this(amount, currency, String.valueOf(expiresAt), description, refund_invoice);
+    }
 }

--- a/src/main/java/cc/getportal/command/request/RequestInvoiceParams.java
+++ b/src/main/java/cc/getportal/command/request/RequestInvoiceParams.java
@@ -15,10 +15,16 @@ public record RequestInvoiceParams(
     @SerializedName("expires_at")
     String expiresAt,
     @Nullable String description,
-    @Nullable String refund_invoice
+    @Nullable String refund_invoice,
+    /** Optional request ID. If not provided, the command ID is used by the server. */
+    @Nullable String request_id
 ) {
-    
+
     public RequestInvoiceParams(long amount, Currency currency, long expiresAt, @Nullable String description, @Nullable String refund_invoice) {
-        this(amount, currency, String.valueOf(expiresAt), description, refund_invoice);
+        this(amount, currency, String.valueOf(expiresAt), description, refund_invoice, null);
+    }
+
+    public RequestInvoiceParams(long amount, Currency currency, long expiresAt, @Nullable String description, @Nullable String refund_invoice, @Nullable String requestId) {
+        this(amount, currency, String.valueOf(expiresAt), description, refund_invoice, requestId);
     }
 }

--- a/src/main/java/cc/getportal/command/request/RequestInvoiceParams.java
+++ b/src/main/java/cc/getportal/command/request/RequestInvoiceParams.java
@@ -1,0 +1,18 @@
+package cc.getportal.command.request;
+
+import cc.getportal.model.Currency;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Slim parameters for RequestInvoice command.
+ * Server (portal-rest) computes exchange rate from amount/currency.
+ * Request ID is derived from command.id.
+ */
+public record RequestInvoiceParams(
+    long amount,
+    Currency currency,
+    String expires_at,
+    @Nullable String description,
+    @Nullable String refund_invoice
+) {
+}

--- a/src/main/java/cc/getportal/command/request/RequestInvoiceRequest.java
+++ b/src/main/java/cc/getportal/command/request/RequestInvoiceRequest.java
@@ -1,6 +1,5 @@
 package cc.getportal.command.request;
 
-import cc.getportal.model.InvoiceRequestContent;
 import cc.getportal.command.PortalRequest;
 import cc.getportal.command.notification.UnitNotification;
 import cc.getportal.command.response.RequestInvoiceResponse;
@@ -11,9 +10,9 @@ public class RequestInvoiceRequest extends PortalRequest<RequestInvoiceResponse,
 
     private final String recipient_key;
     private final List<String> subkeys;
-    private final InvoiceRequestContent content;
+    private final RequestInvoiceParams content;
 
-    public RequestInvoiceRequest(String recipientKey, List<String> subkeys, InvoiceRequestContent content) {
+    public RequestInvoiceRequest(String recipientKey, List<String> subkeys, RequestInvoiceParams content) {
         recipient_key = recipientKey;
         this.subkeys = subkeys;
         this.content = content;


### PR DESCRIPTION
## Release 0.3.0

Aligns java-sdk version with portal-rest 0.3.0 and portal-sdk 0.3.0. Starting from this release, major.minor versions are kept in sync across all three (patch remains independent).

### Changes
- Bump version: `0.2.1` → `0.3.0` in `build.gradle.kts`
- Includes slim `RequestInvoiceParams` (from PR #4):
  - `current_exchange_rate` removed (server computes it)
  - `request_id` is now optional (defaults to command ID if omitted)
  - `expires_at` constructor accepts `long` like other `*Params` classes

### After merge
- Tag `0.3.0` → JitPack picks it up automatically
- Corresponding lib PR: PortalTechnologiesInc/lib#163