### PR TITLE
ci: add build check workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Compile
+        run: ./gradlew compileJava
+
+      - name: Build
+        run: ./gradlew build


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs `compileJava` + `build` on every push and PR.

Merge this first so PRs (starting from #7) get build validation automatically.